### PR TITLE
feat: GA 세팅

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@floating-ui/react": "^0.26.9",
+        "@next/third-parties": "^14.1.1",
         "@tanstack/react-query": "^5.20.5",
         "cors": "^2.8.5",
         "next": "14.1.0",
@@ -2586,6 +2587,18 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@next/third-parties": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-14.1.1.tgz",
+      "integrity": "sha512-Z3xGaalLRd9a1JNSwYzcTIcFyWTCi7o9fGTa2f+ibE1sc2zvxRbBNDyHz0sL+5yGmlxqsLIERPhB6W/GQkKgXQ==",
+      "dependencies": {
+        "third-party-capital": "1.0.20"
+      },
+      "peerDependencies": {
+        "next": "^13.0.0 || ^14.0.0",
+        "react": "^18.2.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -11242,6 +11255,11 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "node_modules/third-party-capital": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
+      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA=="
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@floating-ui/react": "^0.26.9",
+    "@next/third-parties": "^14.1.1",
     "@tanstack/react-query": "^5.20.5",
     "cors": "^2.8.5",
     "next": "14.1.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,4 @@
+import { GoogleAnalytics } from '@next/third-parties/google';
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 
@@ -8,6 +9,8 @@ import GlobalStyle from './GlobalStyle';
 import { ReactQueryClientProvider } from './ReactQueryClientProvider';
 
 const inter = Inter({ subsets: ['latin'] });
+
+const gaId = process.env.GA_ID ?? '';
 
 export const metadata: Metadata = {
   title: 'NextPwa',
@@ -30,6 +33,7 @@ export default function RootLayout({
           </StyledComponentsRegistry>
         </ReactQueryClientProvider>
       </body>
+      <GoogleAnalytics gaId={gaId} />
     </html>
   );
 }


### PR DESCRIPTION
## 작업 내용

> GA(Google 애널리틱스) 세팅
> @next/third-parties 패키지 추가

## 특이 사항
- `.env.local` 파일에 `GA_ID=` 추가 필요. (ga 아이디 공유 예정)
- @next/third-parties 설치 필요

## 참고 자료
- https://nextjs.org/docs/messages/next-script-for-ga#possible-ways-to-fix-it

```ts
// app/layout.tsx
import { GoogleAnalytics } from '@next/third-parties/google'
 
export default function RootLayout({
  children,
}: {
  children: React.ReactNode
}) {
  return (
    <html lang="en">
      <body>{children}</body>
      <GoogleAnalytics gaId="G-XYZ" />
    </html>
  )
}
```