### PR TITLE
feat: 헬스장 미선택 계정 로그인 시 헬스장 선택 페이지로 리다이렉트

### DIFF
--- a/src/app/_providers/UserRoleMiddleware.tsx
+++ b/src/app/_providers/UserRoleMiddleware.tsx
@@ -13,11 +13,13 @@ export const UserRoleMiddleware = ({
   children: React.ReactNode;
 }) => {
   const [role, setRole] = useState<string | null>();
+  const [gymId, setGymId] = useState<string | null>();
 
   useEffect(() => {
-    const { memberType: currentType } = auth();
+    const { memberType: currentType, gymId: currentGymId } = auth();
     setRole(currentType);
-  }, [memberType]);
+    setGymId(currentGymId);
+  }, [gymId, memberType]);
 
   // 로그인 안된 상태
   if (role === null) return redirect('/');
@@ -25,6 +27,8 @@ export const UserRoleMiddleware = ({
   // 다른 역할로 접근 시
   if (typeof role === 'string' && role !== memberType)
     return redirect(`/${role.toLowerCase()}`);
+
+  if (gymId === null) return redirect('/selectgym');
 
   if (typeof role === 'string' && role === memberType) return children;
 

--- a/src/entities/auth/model/store.ts
+++ b/src/entities/auth/model/store.ts
@@ -19,6 +19,7 @@ const DEFAULT_AUTH_STATE = {
   memberType: null,
   refreshToken: null,
   accessToken: null,
+  gymId: null,
 };
 
 const authStore = () => DEFAULT_AUTH_STATE;
@@ -30,6 +31,7 @@ const useAuthStore = create(
       'memberType',
       'refreshToken',
       'accessToken',
+      'gymId',
     ]),
     { name: AUTH_STATE_NAME }
   )
@@ -53,9 +55,9 @@ const auth = () => {
   const { state } = JSON.parse(store) as {
     state: UserInfo;
   };
-  const { accessToken, refreshToken, memberType } = state;
+  const { accessToken, refreshToken, memberType, gymId } = state;
   const tokens = { accessToken, refreshToken };
-  return { tokens, memberType };
+  return { tokens, memberType, gymId };
 };
 
 export { auth, useAuthAction, useAuthSelector };

--- a/src/entities/auth/model/types.ts
+++ b/src/entities/auth/model/types.ts
@@ -9,6 +9,7 @@ interface SignInResponse {
   refreshToken: string;
   memberType: 'STUDENT' | 'TRAINER';
   userId: string;
+  gymId: string | null;
 }
 
 interface UserInfo {
@@ -16,6 +17,7 @@ interface UserInfo {
   memberType: string | null;
   refreshToken: string | null;
   accessToken: string | null;
+  gymId: string | null;
 }
 
 type Provider = 'kakao' | 'naver' | 'google';

--- a/src/shared/ui/navigation.tsx
+++ b/src/shared/ui/navigation.tsx
@@ -6,9 +6,9 @@ import { usePathname } from 'next/navigation';
 import IconAccountFilled from '@/shared/assets/images/nav_account_filled.svg';
 import IconAccountOutlined from '@/shared/assets/images/nav_account_outlined.svg';
 import IconCalendarFilled from '@/shared/assets/images/nav_calendar_filled.svg';
-import IconCalendarOutlined from '@/shared/assets/images/nav_calendar_Outlined.svg';
+import IconCalendarOutlined from '@/shared/assets/images/nav_calendar_outlined.svg';
 import IconHomeFilled from '@/shared/assets/images/nav_home_filled.svg';
-import IconHomeOutlined from '@/shared/assets/images/nav_home_Outlined.svg';
+import IconHomeOutlined from '@/shared/assets/images/nav_home_outlined.svg';
 import { cn } from '@/shared/utils/tw-utils';
 
 const TrainerNavigation = () => {


### PR DESCRIPTION
## 작업 개요

헬스장 미선택 계정 로그인 시 헬스장 선택 페이지로 리다이렉트

## 작업 분류

- [x] 헬스장 미선택 계정 로그인 시 헬스장 선택 페이지로 리다이렉트
- [x] login 응답값의 gymId를 auth zustand에 추가

## 작업 상세 내용

헬스장 미선택 계정 로그인 시 헬스장 선택 페이지로 이동되도록 UserRoleMiddleware에 로직 추가를 했습니다.